### PR TITLE
未使用の src/runtime.rs を削除

### DIFF
--- a/crates/ps88/src/runtime.rs
+++ b/crates/ps88/src/runtime.rs
@@ -1,3 +1,0 @@
-pub mod js;
-pub mod js_sync;
-pub mod runtime;


### PR DESCRIPTION
## 概要
#7 の 1-6 の修正です。

`crates/ps88/src/runtime.rs` は `lib.rs` のモジュール宣言に含まれておらず、存在しない `js_sync` モジュールを参照しているデッドファイルだったため削除します。

`cargo check` が通ることを確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)