### PR TITLE
runtime_actor の test_save_load が RuntimeActor をテストするように修正

### DIFF
--- a/crates/ps88/src/js/ps88js/runtime_actor.rs
+++ b/crates/ps88/src/js/ps88js/runtime_actor.rs
@@ -346,7 +346,7 @@ mod tests {
     #[test]
     fn test_save_load() {
         let userdata = Arc::new(Mutex::new(UserData::None));
-        let mut rt = Runtime::new(userdata.clone()).unwrap();
+        let rt = RuntimeActor::new(userdata.clone()).unwrap();
         let (tx, rx) = channel();
         rt.add_logger(Box::new(move |msg: String| {
             tx.send(msg).unwrap();


### PR DESCRIPTION
## 概要
#7 の 2-2 の修正です。

`runtime_actor.rs` の `test_save_load` が `Runtime::new` を使っており(runtime.rs のテストのコピペ由来と思われます)、アクタースレッド越しの save/load が検証されていませんでした。`RuntimeActor::new` を使うように修正します。

`cargo test` 全件成功を確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)