### PR TITLE
clippy / コンパイラ警告 30 件を解消

### DIFF
--- a/crates/ps88/src/file_watcher.rs
+++ b/crates/ps88/src/file_watcher.rs
@@ -49,7 +49,7 @@ impl Watcher for WatcherImpl {
             },
         }?;
         self.watcher = Some(watcher);
-        return Ok(rx);
+        Ok(rx)
     }
 }
 
@@ -61,32 +61,20 @@ pub fn relay_latest<Msg: Send + 'static>(
 ) -> std::sync::mpsc::Receiver<Msg> {
     let (tx_new, rx_new) = std::sync::mpsc::channel::<Msg>();
     std::thread::spawn(move || {
-        let mut last_msg;
-
-        'outer: loop {
-            match rx.recv() {
-                Ok(msg) => {
-                    last_msg = Some(msg);
-                    'inner: loop {
-                        match rx.recv_timeout(dur) {
-                            Ok(msg) => {
-                                last_msg = Some(msg);
-                                continue 'inner;
-                            }
-                            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                                if let Some(msg) = last_msg {
-                                    let _ = tx_new.send(msg);
-                                }
-                                break 'inner;
-                            }
-                            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                                break 'outer;
-                            }
-                        }
+        'outer: while let Ok(msg) = rx.recv() {
+            let mut last_msg = msg;
+            loop {
+                match rx.recv_timeout(dur) {
+                    Ok(msg) => {
+                        last_msg = msg;
                     }
-                }
-                Err(_) => {
-                    break;
+                    Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                        let _ = tx_new.send(last_msg);
+                        break;
+                    }
+                    Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                        break 'outer;
+                    }
                 }
             }
         }

--- a/crates/ps88/src/gui/editor.rs
+++ b/crates/ps88/src/gui/editor.rs
@@ -45,7 +45,7 @@ pub fn editor(
             return false;
         };
         logger.lock().unwrap().push((log, LogType::Info));
-        return true;
+        true
     }));
     create_egui_editor(
         EguiState::from_size(640 + 200, 480 + 30),
@@ -144,7 +144,7 @@ pub fn editor(
                                     let result = rfd::FileDialog::new().pick_file();
                                     if let Some(path) = result {
                                         if let Ok(watcher) = load_script(&path, move |code| {
-                                            if let Err(err) = runtime.compile(&*code) {
+                                            if let Err(err) = runtime.compile(&code) {
                                                 if let Some(logger) = weak_log.upgrade() {
                                                     logger
                                                         .lock()
@@ -171,7 +171,7 @@ pub fn editor(
                                 if ui.button("paste").clicked() {
                                     if let Ok(mut clipboard) = arboard::Clipboard::new() {
                                         if let Ok(code) = clipboard.get_text() {
-                                            if let Err(err) = runtime.compile(&*code) {
+                                            if let Err(err) = runtime.compile(&code) {
                                                 state
                                                     .log
                                                     .lock()
@@ -205,7 +205,7 @@ fn load_script<F: Fn(String) + Sync + Send + 'static>(
     path: &std::path::Path,
     callback: F,
 ) -> Result<Box<dyn Watcher + Send + Sync>, ()> {
-    let Ok(mut file) = std::fs::File::open(&path) else {
+    let Ok(mut file) = std::fs::File::open(path) else {
         return Err(());
     };
     let mut code = String::new();
@@ -230,5 +230,5 @@ fn load_script<F: Fn(String) + Sync + Send + 'static>(
         }
     });
     // 呼び出し元が watcher を drop することでファイル監視が終了するようにする
-    return Ok(watcher);
+    Ok(watcher)
 }

--- a/crates/ps88/src/js/core/api.rs
+++ b/crates/ps88/src/js/core/api.rs
@@ -122,7 +122,7 @@ impl<'a, T: This<'a>> ApiTrait<'a> for Api<'a, T> {
         }
         let obj = obj_t
             .new_instance(scope)
-            .ok_or(JsRuntimeError::UnexpectedError(
+            .ok_or(JsRuntimeError::Unexpected(
                 "failed to create api object".into(),
             ))?;
         let name = v8str(scope, &self.name)?;

--- a/crates/ps88/src/js/core/error.rs
+++ b/crates/ps88/src/js/core/error.rs
@@ -3,11 +3,11 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum JsRuntimeError {
     #[error("failed to compile: `{0}`")]
-    CompileError(String),
+    Compile(String),
     #[error("failed to process: `{0}`")]
-    RuntimeError(String),
+    Runtime(String),
     #[error("unexpected error: {0}")]
-    UnexpectedError(String),
+    Unexpected(String),
 }
 
 pub type Result<T> = std::result::Result<T, JsRuntimeError>;
@@ -15,6 +15,6 @@ pub type Result<T> = std::result::Result<T, JsRuntimeError>;
 pub fn wrap_err<T, E: ToString>(e: std::result::Result<T, E>) -> Result<T> {
     match e {
         Ok(v) => Ok(v),
-        Err(err) => Err(JsRuntimeError::UnexpectedError(err.to_string())),
+        Err(err) => Err(JsRuntimeError::Unexpected(err.to_string())),
     }
 }

--- a/crates/ps88/src/js/core/runtime.rs
+++ b/crates/ps88/src/js/core/runtime.rs
@@ -6,9 +6,12 @@ use deno_core::v8;
 use std::rc::Rc;
 use std::sync::Once;
 
+// console.log() の出力を受け取るロガー関数
+pub type Logger<'a> = Box<dyn Fn(String) + 'a>;
+
 pub struct JsRuntimeBuilder<'a> {
     api: Vec<Box<dyn ApiTrait<'a>>>,
-    logger: Vec<Box<dyn Fn(String) + 'a>>,
+    logger: Vec<Logger<'a>>,
 }
 
 impl<'a> JsRuntimeBuilder<'a> {
@@ -47,14 +50,14 @@ pub struct JsRuntime<'a> {
     api: Vec<Box<dyn ApiTrait<'a>>>,
 
     // console.log() の出力を得るためのロガー
-    logger: Rc<Vec<Box<dyn Fn(String) + 'a>>>,
+    logger: Rc<Vec<Logger<'a>>>,
 }
 
 impl<'a> JsRuntime<'a> {
-    fn new(api: Vec<Box<dyn ApiTrait<'a>>>, logger: Vec<Box<dyn Fn(String) + 'a>>) -> Result<Self> {
+    fn new(api: Vec<Box<dyn ApiTrait<'a>>>, logger: Vec<Logger<'a>>) -> Result<Self> {
         // V8 の初期化
-        static PUPPY_INIT: Once = Once::new();
-        PUPPY_INIT.call_once(move || {
+        static V8_INIT: Once = Once::new();
+        V8_INIT.call_once(move || {
             let platform = v8::new_default_platform(0, false).make_shared();
             v8::V8::initialize_platform(platform);
             v8::V8::initialize();
@@ -100,7 +103,7 @@ impl<'a> JsRuntime<'a> {
     }
 
     // JavaScript の実行環境をリセット
-    pub fn reset<'b>(&'b mut self) -> Result<()> {
+    pub fn reset(&mut self) -> Result<()> {
         // api の this をリセット
         self.api.iter().for_each(|api| api.reset());
 
@@ -135,19 +138,19 @@ impl<'a> JsRuntime<'a> {
     }
 
     // スクリプトを実行
-    pub fn run(&mut self, code: &str) -> Result<v8::Local<v8::Value>> {
+    pub fn run(&mut self, code: &str) -> Result<v8::Local<'_, v8::Value>> {
         let scope = &mut v8::HandleScope::with_context(&mut self.isolate, &self.context);
         let code = v8str(scope, code)?;
         let try_catch = &mut v8::TryCatch::new(scope);
         let script = v8::Script::compile(try_catch, code, None)
-            .ok_or(JsRuntimeError::CompileError(report_exceptions(try_catch)))?;
+            .ok_or(JsRuntimeError::Compile(report_exceptions(try_catch)))?;
         let result = script
             .run(try_catch)
-            .ok_or(JsRuntimeError::RuntimeError(report_exceptions(try_catch)))?;
+            .ok_or(JsRuntimeError::Runtime(report_exceptions(try_catch)))?;
         Ok(result)
     }
 
-    pub fn scope(&mut self) -> v8::HandleScope {
+    pub fn scope(&mut self) -> v8::HandleScope<'_> {
         v8::HandleScope::with_context(&mut self.isolate, &self.context)
     }
 }
@@ -167,11 +170,11 @@ mod tests {
 
         // 構文エラーが適切に報告される
         let result = rt.run("1 + ");
-        assert!(matches!(result, Err(JsRuntimeError::CompileError(_))));
+        assert!(matches!(result, Err(JsRuntimeError::Compile(_))));
 
         // 実行時エラーが適切に報告される
         let result = rt.run("throw new Error('test error')");
-        assert!(matches!(result, Err(JsRuntimeError::RuntimeError(_))));
+        assert!(matches!(result, Err(JsRuntimeError::Runtime(_))));
     }
 
     #[test]
@@ -270,7 +273,7 @@ mod tests {
 
         // 引数の型が違う場合は適切に例外が投げられる
         let result = rt.run("test_counter.add('a');");
-        assert!(matches!(result, Err(JsRuntimeError::RuntimeError(_))));
+        assert!(matches!(result, Err(JsRuntimeError::Runtime(_))));
 
         // reset 後も問題なく動く
         rt.reset().unwrap();

--- a/crates/ps88/src/js/core/utils.rs
+++ b/crates/ps88/src/js/core/utils.rs
@@ -5,7 +5,7 @@ pub fn v8str<'s>(
     scope: &mut v8::HandleScope<'s, ()>,
     s: &str,
 ) -> Result<v8::Local<'s, v8::String>> {
-    let name = v8::String::new(scope, s).ok_or(JsRuntimeError::UnexpectedError(format!(
+    let name = v8::String::new(scope, s).ok_or(JsRuntimeError::Unexpected(format!(
         "failed to create string: {}",
         s
     )))?;
@@ -84,8 +84,8 @@ pub fn report_exceptions(try_catch: &mut v8::TryCatch<v8::HandleScope>) -> Strin
         .and_then(|s| s.to_string(try_catch))
         .map(|s| s.to_rust_string_lossy(try_catch))
     {
-        description.push(format!("{}", stack_trace));
+        description.push(stack_trace.to_string());
     }
 
-    return description.join("\n");
+    description.join("\n")
 }

--- a/crates/ps88/src/js/ps88js/convert.rs
+++ b/crates/ps88/src/js/ps88js/convert.rs
@@ -46,7 +46,7 @@ pub(super) fn obj_to_midi(
 ) -> core::Result<Vec<NoteEvent>> {
     match serde_v8::from_v8::<Vec<NoteEvent>>(scope, arr) {
         Ok(midi) => Ok(midi),
-        Err(e) => Err(core::JsRuntimeError::RuntimeError(format!(
+        Err(e) => Err(core::JsRuntimeError::Runtime(format!(
             "failed to convert midi from v8: {}",
             e
         ))),
@@ -85,13 +85,13 @@ pub(super) fn audio_to_backing_store<'a, 'b>(
                 );
             }
         } else if input_size > 0 {
-            return Err(core::JsRuntimeError::UnexpectedError(
+            return Err(core::JsRuntimeError::Unexpected(
                 "failed to get backing store data pointer".to_string(),
             ));
         }
         let float32array =
             v8::Float32Array::new(scope, array_buffer, offset * bytes_per_sample, ch.len()).ok_or(
-                core::JsRuntimeError::UnexpectedError("failed to create Float32Array".to_string()),
+                core::JsRuntimeError::Unexpected("failed to create Float32Array".to_string()),
             )?;
         float32arrays.push(float32array);
         offset += ch.len();

--- a/crates/ps88/src/js/ps88js/global_api.rs
+++ b/crates/ps88/src/js/ps88js/global_api.rs
@@ -61,10 +61,10 @@ impl Api {
             *userdata = UserData::None;
             return;
         }
-        return core::v8throw_type_error(
+        core::v8throw_type_error(
             info.scope,
-            &format!("argument must be a Uint8Array, string, null, or undefined"),
-        );
+            "argument must be a Uint8Array, string, null, or undefined",
+        )
     }
     pub(super) fn load(&mut self, mut info: core::CallbackInfo) {
         let status = self.status.borrow();
@@ -77,7 +77,6 @@ impl Api {
         match &*userdata {
             UserData::None => {
                 info.rv.set_null();
-                return;
             }
             UserData::Text(text) => {
                 let v8_str = match v8::String::new(info.scope, text) {
@@ -87,7 +86,6 @@ impl Api {
                     }
                 };
                 info.rv.set(v8_str.into());
-                return;
             }
             UserData::Bytes(bytes) => {
                 let backing_store =
@@ -99,9 +97,8 @@ impl Api {
                     return core::v8throw(info.scope, "failed to create Uint8Array");
                 };
                 info.rv.set(uint8_array.into());
-                return;
             }
-        };
+        }
     }
 }
 impl core::This<'_> for Api {

--- a/crates/ps88/src/js/ps88js/gui_api.rs
+++ b/crates/ps88/src/js/ps88js/gui_api.rs
@@ -22,8 +22,8 @@ pub enum Shape {
     },
 }
 
-pub(super) fn gen_api_add_polygon<'a, 'b>(
-    scope: &'a mut v8::HandleScope<'b>,
+pub(super) fn gen_api_add_polygon<'b>(
+    scope: &mut v8::HandleScope<'b>,
     shapes: v8::Local<'b, v8::Array>,
 ) -> core::Result<v8::Local<'b, v8::Function>> {
     fn callback(
@@ -69,7 +69,7 @@ pub(super) fn gen_api_add_polygon<'a, 'b>(
             stroke_closed: options.as_ref().and_then(|o| o.stroke_closed),
         };
         let shape_js = match serde_v8::to_v8(scope, &shape) {
-            Ok(v) => v.into(),
+            Ok(v) => v,
             Err(err) => {
                 return core::v8throw(scope, &format!("unexpected: {}", err));
             }
@@ -79,13 +79,13 @@ pub(super) fn gen_api_add_polygon<'a, 'b>(
     v8::FunctionBuilder::<v8::Function>::new(callback)
         .data(shapes.into())
         .build(scope)
-        .ok_or(core::JsRuntimeError::RuntimeError(
+        .ok_or(core::JsRuntimeError::Runtime(
             "failed to create add_polygon function".to_string(),
         ))
 }
 
-pub(super) fn gen_api_add_text<'a, 'b>(
-    scope: &'a mut v8::HandleScope<'b>,
+pub(super) fn gen_api_add_text<'b>(
+    scope: &mut v8::HandleScope<'b>,
     shapes: v8::Local<'b, v8::Array>,
 ) -> core::Result<v8::Local<'b, v8::Function>> {
     fn callback(
@@ -142,7 +142,7 @@ pub(super) fn gen_api_add_text<'a, 'b>(
             color: options.as_ref().and_then(|o| o.color),
         };
         let shape_js = match serde_v8::to_v8(scope, &shape) {
-            Ok(v) => v.into(),
+            Ok(v) => v,
             Err(err) => {
                 return core::v8throw(scope, &format!("unexpected: {}", err));
             }
@@ -152,7 +152,7 @@ pub(super) fn gen_api_add_text<'a, 'b>(
     v8::FunctionBuilder::<v8::Function>::new(callback)
         .data(shapes.into())
         .build(scope)
-        .ok_or(core::JsRuntimeError::RuntimeError(
+        .ok_or(core::JsRuntimeError::Runtime(
             "failed to create add_text function".to_string(),
         ))
 }

--- a/crates/ps88/src/js/ps88js/runtime.rs
+++ b/crates/ps88/src/js/ps88js/runtime.rs
@@ -8,11 +8,14 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
+// ログ関数。false を返すとログの受信が終了する。
+type Logger = Box<dyn Fn(String) -> bool>;
+
 pub struct Runtime<'a> {
     status: Rc<RefCell<Status>>,
     runtime: core::JsRuntime<'a>,
     audio_buf: Option<v8::SharedRef<v8::BackingStore>>,
-    logger: Rc<RefCell<Vec<Box<dyn Fn(String) -> bool>>>>,
+    logger: Rc<RefCell<Vec<Logger>>>,
 }
 
 impl Runtime<'_> {
@@ -32,7 +35,7 @@ impl Runtime<'_> {
         .add("gui", Api::gui)
         .add("save", Api::save)
         .add("load", Api::load);
-        let logger = Rc::new(RefCell::new(Vec::<Box<dyn Fn(String) -> bool>>::new()));
+        let logger = Rc::new(RefCell::new(Vec::<Logger>::new()));
         let logger2 = logger.clone();
         let logger_func = move |msg: String| {
             logger2.replace(
@@ -102,7 +105,7 @@ impl Runtime<'_> {
             {
                 let try_catch = &mut v8::TryCatch::new(scope);
                 callback.call(try_catch, this, &[ctx]).ok_or(
-                    core::JsRuntimeError::RuntimeError(core::report_exceptions(try_catch)),
+                    core::JsRuntimeError::Runtime(core::report_exceptions(try_catch)),
                 )?;
             }
 
@@ -152,13 +155,13 @@ impl Runtime<'_> {
             {
                 let try_catch = &mut v8::TryCatch::new(scope);
                 callback.call(try_catch, this, &[ctx]).ok_or(
-                    core::JsRuntimeError::RuntimeError(core::report_exceptions(try_catch)),
+                    core::JsRuntimeError::Runtime(core::report_exceptions(try_catch)),
                 )?;
             }
 
             // 結果を shapes に書き戻す
             serde_v8::from_v8::<Vec<Shape>>(scope, shapes.into())
-                .map_err(|e| core::JsRuntimeError::RuntimeError(format!("serde error: {}", e)))
+                .map_err(|e| core::JsRuntimeError::Runtime(format!("serde error: {}", e)))
         }();
         if result.is_err() {
             // エラーが起きたら状態をリセット

--- a/crates/ps88/src/js/ps88js/runtime_actor.rs
+++ b/crates/ps88/src/js/ps88js/runtime_actor.rs
@@ -28,7 +28,8 @@ impl RuntimeActor {
             for msg in rx {
                 match msg {
                     RuntimeActorMessage::AddLogger { logger, result } => {
-                        result.send(runtime.add_logger(logger)).unwrap();
+                        runtime.add_logger(logger);
+                        result.send(()).unwrap();
                     }
                     RuntimeActorMessage::Reset { result } => {
                         result.send(runtime.reset()).unwrap();
@@ -72,7 +73,7 @@ impl RuntimeActor {
         let (tx, rx) = channel();
         self.sender
             .send(RuntimeActorMessage::AddLogger {
-                logger: logger,
+                logger,
                 result: tx,
             })
             .unwrap();

--- a/crates/ps88/src/lib.rs
+++ b/crates/ps88/src/lib.rs
@@ -83,7 +83,7 @@ impl Plugin for PS88 {
         {
             if let Err(err) = self
                 .runtime
-                .compile(&*self.params.code.lock().unwrap().clone())
+                .compile(&self.params.code.lock().unwrap().clone())
             {
                 log::error!("{}", err);
             }

--- a/crates/ps88/src/params.rs
+++ b/crates/ps88/src/params.rs
@@ -2,7 +2,7 @@ use crate::js::ps88js::UserData;
 use nih_plug::prelude::*;
 use std::sync::{Arc, Mutex};
 
-const DEFAULT_SCRIPT: &'static str = std::include_str!("default_script.js");
+const DEFAULT_SCRIPT: &str = std::include_str!("default_script.js");
 
 // プラグイン内で保持するデータ
 #[derive(Params)]


### PR DESCRIPTION
## 概要
#7 の 3-8 の修正です。clippy 警告 28 件 + cargo check 警告 2 件をすべて解消し、警告 0 件にしました。

- `cargo clippy --fix` による自動修正(不要な `return`、auto-deref、不要な `format!` など 24 件)
- `JsRuntimeError` の variant から `Error` 後置を除去 (`CompileError` → `Compile` など、enum_variant_names)
- `relay_latest` のループを `while let` に書き換え (while_let_loop)。挙動は既存テストで担保
- ロガー型に `Logger` エイリアスを導入 (type_complexity)
- `run()` / `scope()` の戻り値ライフタイムに `'_` を明示 (mismatched_lifetime_syntaxes)
- `PUPPY_INIT` → `V8_INIT` に改名(別プロジェクト由来と思われる名前だったため)

`cargo clippy` 警告 0 件、`cargo test` 12 件全て成功を確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)