### PR TITLE
README のビルド手順から submodule 行を削除

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -49,7 +49,6 @@ ps88.audio((ctx) => {
 
 ```sh
 git clone https://github.com/wakewakame/ps88.git
-git submodule update --init --recursive
 cd ps88
 cargo install --git https://github.com/robbert-vdh/nih-plug --rev 28b149ec4d62757d0b448809148a0c3ca6e09a95 xtask
 xtask bundle ps88 --release

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ After installing [Rust](https://www.rust-lang.org/tools/install), run the follow
 
 ```sh
 git clone https://github.com/wakewakame/ps88.git
-git submodule update --init --recursive
 cd ps88
 cargo install --git https://github.com/robbert-vdh/nih-plug --rev 28b149ec4d62757d0b448809148a0c3ca6e09a95 xtask
 xtask bundle ps88 --release


### PR DESCRIPTION
## 概要
#7 の 4-3 の修正です。

ビルド手順の `git submodule update --init --recursive` は、

- `.gitmodules` が存在せずサブモジュールを使っていない
- `cd ps88` より前(リポジトリ外)で実行する順序になっていた

の 2 点から、README.md / README.ja.md の両方から削除しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)