### PR TITLE
テッセレーション失敗時に JS ランタイムを reset しないようにする

### DIFF
--- a/crates/ps88/src/gui/canvas.rs
+++ b/crates/ps88/src/gui/canvas.rs
@@ -86,9 +86,6 @@ impl egui::Widget for CanvasWidget {
                         );
                         if let Err(err) = result {
                             log::error!("failed to tessellate fill: {}", err);
-                            if let Err(err) = self.0.reset() {
-                                log::error!("failed to reset runtime: {}", err);
-                            }
                             continue;
                         }
                         let mesh = egui::Shape::Mesh(
@@ -125,10 +122,7 @@ impl egui::Widget for CanvasWidget {
                             }),
                         );
                         if let Err(err) = result {
-                            log::error!("failed to tessellate fill: {}", err);
-                            if let Err(err) = self.0.reset() {
-                                log::error!("failed to reset runtime: {}", err);
-                            }
+                            log::error!("failed to tessellate stroke: {}", err);
                             continue;
                         }
                         let mesh = egui::Shape::Mesh(

--- a/crates/ps88/src/js/ps88js/runtime_actor.rs
+++ b/crates/ps88/src/js/ps88js/runtime_actor.rs
@@ -30,9 +30,6 @@ impl RuntimeActor {
                     RuntimeActorMessage::AddLogger { logger, result } => {
                         result.send(runtime.add_logger(logger)).unwrap();
                     }
-                    RuntimeActorMessage::Reset { result } => {
-                        result.send(runtime.reset()).unwrap();
-                    }
                     RuntimeActorMessage::Compile { code, result } => {
                         result.send(runtime.compile(&code)).unwrap();
                     }
@@ -75,13 +72,6 @@ impl RuntimeActor {
                 logger: logger,
                 result: tx,
             })
-            .unwrap();
-        rx.recv().unwrap()
-    }
-    pub fn reset(&self) -> core::Result<()> {
-        let (tx, rx) = channel();
-        self.sender
-            .send(RuntimeActorMessage::Reset { result: tx })
             .unwrap();
         rx.recv().unwrap()
     }
@@ -173,9 +163,6 @@ enum RuntimeActorMessage {
     AddLogger {
         logger: Box<dyn Fn(String) -> bool + Sync + Send>,
         result: Sender<()>,
-    },
-    Reset {
-        result: Sender<core::Result<()>>,
     },
     Compile {
         code: String,


### PR DESCRIPTION
## 概要
#7 の 2-3 の修正です。

lyon のテッセレーションが失敗した際に `runtime.reset()` を呼んでおり、描画側の問題でユーザースクリプトの全状態(audio コールバック含む)が破壊されていました。音まで止まるのは影響が大きすぎるため、該当 Shape の描画をスキップしてログを出すだけに変更します。

あわせて以下も対応しています。

- stroke 側のエラーメッセージが `failed to tessellate fill` になっていたコピペミスを修正
- canvas.rs が唯一の呼び出し元だった `RuntimeActor::reset` / `RuntimeActorMessage::Reset` が dead code になるため削除(内部の `Runtime::reset` はエラー時リセットで使用されるため残置)

`cargo check` 警告 0 件、`cargo test` 全件成功を確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)