### PR TITLE
テキスト描画のデフォルト色を白にする

### DIFF
--- a/crates/ps88/src/gui/canvas.rs
+++ b/crates/ps88/src/gui/canvas.rs
@@ -151,7 +151,8 @@ impl egui::Widget for CanvasWidget {
                     size,
                     color,
                 } => {
-                    let color = color.unwrap_or(0x000000FF);
+                    // ダークテーマ背景でも見えるようデフォルトは白にする
+                    let color = color.unwrap_or(0xFFFFFFFF);
                     let color = egui::Color32::from_rgba_unmultiplied(
                         (color >> 24) as u8,
                         ((color >> 16) & 0xff) as u8,


### PR DESCRIPTION
## 概要
#7 の 2-7 の修正です。

`addText` の色未指定時のデフォルトが黒 (`0x000000FF`) で、egui のダークテーマ背景ではほぼ見えませんでした。デフォルトスクリプトの波形描画が白 (`0xFFFFFFFF`) を使っているのとも合わせ、白をデフォルトにします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)