### PR TITLE
未実装の hot reload チェックボックスを無効表示にする

### DIFF
--- a/crates/ps88/src/gui/editor.rs
+++ b/crates/ps88/src/gui/editor.rs
@@ -162,8 +162,11 @@ pub fn editor(
                                     }
                                 });
                             }
-                            let mut check = true; // TODO
-                            ui.checkbox(&mut check, "hot reload");
+                            // TODO: ホットリロードの ON/OFF 切り替えは未実装。
+                            // 操作できるように見えないよう、実装までは無効表示にしておく。
+                            let mut check = true;
+                            ui.add_enabled(false, egui::Checkbox::new(&mut check, "hot reload"))
+                                .on_disabled_hover_text("not implemented yet");
                             ui.with_layout(egui::Layout::right_to_left(egui::Align::TOP), |ui| {
                                 if ui.button("copy").clicked() {
                                     ui.ctx().copy_text(code.clone());


### PR DESCRIPTION
## 概要
#7 の 2-4 の修正です。

「hot reload」チェックボックスは `let mut check = true; // TODO` のダミーで、操作できるように見えるのに何も制御していませんでした。ユーザーの混乱を避けるため、実装されるまで disabled 表示 + `not implemented yet` のホバーテキストにします。

機能自体の実装(ファイル監視の ON/OFF 切り替え)は別途対応する想定です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)