### PR TITLE
エラー時リセットの失敗が元の JS エラーを隠さないようにする

### DIFF
--- a/crates/ps88/src/js/ps88js/runtime.rs
+++ b/crates/ps88/src/js/ps88js/runtime.rs
@@ -114,7 +114,10 @@ impl Runtime<'_> {
         }();
         if result.is_err() {
             // エラーが起きたら状態をリセット
-            self.reset()?;
+            // NOTE: reset 自体のエラーで元のエラーを隠さないよう、こちらはログに出すだけにする
+            if let Err(err) = self.reset() {
+                log::error!("failed to reset runtime: {}", err);
+            }
         }
         result
     }
@@ -162,7 +165,10 @@ impl Runtime<'_> {
         }();
         if result.is_err() {
             // エラーが起きたら状態をリセット
-            self.reset()?;
+            // NOTE: reset 自体のエラーで元のエラーを隠さないよう、こちらはログに出すだけにする
+            if let Err(err) = self.reset() {
+                log::error!("failed to reset runtime: {}", err);
+            }
         }
         result
     }


### PR DESCRIPTION
## 概要
#7 の 3-5 の修正です。

`Runtime::audio` / `Runtime::gui` では JS エラー発生時に状態をリセットしますが、`self.reset()?` としていたため reset 自体が失敗すると元の JS エラー(ユーザーがデバッグに必要な情報)を捨てて reset のエラーを返していました。

reset の失敗は `log::error!` に出すだけにし、常に元のエラーを返すようにします。

`cargo test` 全件成功を確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)