### PR TITLE
RuntimeActor::drop のダミースレッド生成をやめる

### DIFF
--- a/crates/ps88/src/js/ps88js/runtime_actor.rs
+++ b/crates/ps88/src/js/ps88js/runtime_actor.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex};
 // Runtime は Sync, Send を持たないため、そのままでは複数スレッドから使うことはできない。
 // これを解決するため、Runtime を専用スレッドで動かしチャンネル経由でメソッド呼び出しを行うようにする。
 pub struct RuntimeActor {
-    handle: std::thread::JoinHandle<()>,
+    handle: Option<std::thread::JoinHandle<()>>,
     sender: Sender<RuntimeActorMessage>,
 
     // メソッドの引数は通常チャンネルで渡すが、サイズの大きいデータや参照型などは args 経由でやり取りする
@@ -62,7 +62,7 @@ impl RuntimeActor {
             }
         });
         Ok(Self {
-            handle,
+            handle: Some(handle),
             sender: tx,
             args,
         })
@@ -157,10 +157,13 @@ impl RuntimeActor {
 }
 impl Drop for RuntimeActor {
     fn drop(&mut self) {
+        // sender を drop してアクタースレッドの受信ループを終了させる
         let sender = std::mem::replace(&mut self.sender, std::sync::mpsc::channel().0);
         drop(sender);
-        let handle = std::mem::replace(&mut self.handle, std::thread::spawn(move || {}));
-        handle.join().unwrap();
+        // アクタースレッドが panic していた場合に二重 panic で abort しないよう、join の結果は無視する
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
     }
 }
 


### PR DESCRIPTION
## 概要
#7 の 3-6 の修正です。

`RuntimeActor::drop` が `mem::replace` のためだけにダミーのスレッドを spawn していたのを、`handle: Option<JoinHandle<()>>` + `take()` に変更しました。

また `handle.join().unwrap()` はアクタースレッドが panic していた場合に drop 中の二重 panic → プロセス abort につながるため、join の結果は無視するようにしています(アクタースレッドの panic 対策自体は #7 の 1-3 で別途対応予定です)。

`cargo test` 全件成功を確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)