### PR TITLE
gui_api.rs の add_polygon / add_text の重複を解消

### DIFF
--- a/crates/ps88/src/js/ps88js/gui_api.rs
+++ b/crates/ps88/src/js/ps88js/gui_api.rs
@@ -1,4 +1,5 @@
 use super::super::core;
+use deno_core::serde::de::DeserializeOwned;
 use deno_core::serde::{Deserialize, Serialize};
 use deno_core::{serde_v8, v8};
 
@@ -22,6 +23,58 @@ pub enum Shape {
     },
 }
 
+// index 番目の引数を serde でデコードする。
+// 失敗した場合は JavaScript 側に TypeError を投げて None を返す。
+fn decode_arg<T: DeserializeOwned>(
+    scope: &mut v8::HandleScope,
+    args: &v8::FunctionCallbackArguments,
+    index: i32,
+) -> Option<T> {
+    match serde_v8::from_v8::<T>(scope, args.get(index)) {
+        Ok(v) => Some(v),
+        Err(err) => {
+            core::v8throw_type_error(scope, &format!("arg{}: {}", index, err));
+            None
+        }
+    }
+}
+
+// コールバックの data() に紐付けた配列に shape を追加する
+fn push_shape(scope: &mut v8::HandleScope, args: &v8::FunctionCallbackArguments, shape: Shape) {
+    let shapes = match args.data().try_cast::<v8::Array>() {
+        Ok(v) => v,
+        Err(err) => {
+            return core::v8throw(
+                scope,
+                &format!("unexpected: \"this\" is not an array: {}", err),
+            );
+        }
+    };
+    let shape_js = match serde_v8::to_v8(scope, &shape) {
+        Ok(v) => v,
+        Err(err) => {
+            return core::v8throw(scope, &format!("unexpected: {}", err));
+        }
+    };
+    shapes.set_index(scope, shapes.length(), shape_js);
+}
+
+// callback を shapes 配列に紐付けた v8::Function に変換する
+fn build_shape_fn<'b>(
+    scope: &mut v8::HandleScope<'b>,
+    shapes: v8::Local<'b, v8::Array>,
+    callback: impl v8::MapFnTo<v8::FunctionCallback>,
+    name: &str,
+) -> core::Result<v8::Local<'b, v8::Function>> {
+    v8::FunctionBuilder::<v8::Function>::new(callback)
+        .data(shapes.into())
+        .build(scope)
+        .ok_or(core::JsRuntimeError::RuntimeError(format!(
+            "failed to create {} function",
+            name
+        )))
+}
+
 pub(super) fn gen_api_add_polygon<'a, 'b>(
     scope: &'a mut v8::HandleScope<'b>,
     shapes: v8::Local<'b, v8::Array>,
@@ -31,57 +84,34 @@ pub(super) fn gen_api_add_polygon<'a, 'b>(
         args: v8::FunctionCallbackArguments,
         _: v8::ReturnValue,
     ) {
-        type Arg0 = Vec<(f64, f64)>;
-        #[derive(Deserialize)]
+        #[derive(Deserialize, Default)]
         #[serde(rename_all = "camelCase")]
-        struct Arg1 {
+        struct Options {
             fill: Option<Color>,
             stroke: Option<Color>,
             stroke_width: Option<f64>,
             stroke_closed: Option<bool>,
         }
-        let path = match serde_v8::from_v8::<Arg0>(scope, args.get(0)) {
-            Ok(path) => path,
-            Err(err) => {
-                return core::v8throw_type_error(scope, &format!("arg0: {}", err));
-            }
+        let Some(path) = decode_arg::<Vec<(f64, f64)>>(scope, &args, 0) else {
+            return;
         };
-        let options = match serde_v8::from_v8::<Option<Arg1>>(scope, args.get(1)) {
-            Ok(options) => options,
-            Err(err) => {
-                return core::v8throw_type_error(scope, &format!("arg1: {}", err));
-            }
+        let Some(options) = decode_arg::<Option<Options>>(scope, &args, 1) else {
+            return;
         };
-        let shapes = match args.data().try_cast::<v8::Array>() {
-            Ok(v) => v,
-            Err(err) => {
-                return core::v8throw(
-                    scope,
-                    &format!("unexpected: \"this\" is not an array: {}", err),
-                );
-            }
-        };
-        let shape = Shape::Polygon {
-            path,
-            fill: options.as_ref().and_then(|o| o.fill),
-            stroke: options.as_ref().and_then(|o| o.stroke),
-            stroke_width: options.as_ref().and_then(|o| o.stroke_width),
-            stroke_closed: options.as_ref().and_then(|o| o.stroke_closed),
-        };
-        let shape_js = match serde_v8::to_v8(scope, &shape) {
-            Ok(v) => v.into(),
-            Err(err) => {
-                return core::v8throw(scope, &format!("unexpected: {}", err));
-            }
-        };
-        shapes.set_index(scope, shapes.length(), shape_js);
+        let options = options.unwrap_or_default();
+        push_shape(
+            scope,
+            &args,
+            Shape::Polygon {
+                path,
+                fill: options.fill,
+                stroke: options.stroke,
+                stroke_width: options.stroke_width,
+                stroke_closed: options.stroke_closed,
+            },
+        );
     }
-    v8::FunctionBuilder::<v8::Function>::new(callback)
-        .data(shapes.into())
-        .build(scope)
-        .ok_or(core::JsRuntimeError::RuntimeError(
-            "failed to create add_polygon function".to_string(),
-        ))
+    build_shape_fn(scope, shapes, callback, "add_polygon")
 }
 
 pub(super) fn gen_api_add_text<'a, 'b>(
@@ -93,66 +123,35 @@ pub(super) fn gen_api_add_text<'a, 'b>(
         args: v8::FunctionCallbackArguments,
         _: v8::ReturnValue,
     ) {
-        type Arg0 = String;
-        type Arg1 = f64;
-        type Arg2 = f64;
-        #[derive(Deserialize)]
-        struct Arg3 {
+        #[derive(Deserialize, Default)]
+        struct Options {
             size: Option<f64>,
             color: Option<Color>,
         }
-        let text = match serde_v8::from_v8::<Arg0>(scope, args.get(0)) {
-            Ok(path) => path,
-            Err(err) => {
-                return core::v8throw_type_error(scope, &format!("arg0: {}", err));
-            }
+        let Some(text) = decode_arg::<String>(scope, &args, 0) else {
+            return;
         };
-        let x = match serde_v8::from_v8::<Arg1>(scope, args.get(1)) {
-            Ok(options) => options,
-            Err(err) => {
-                return core::v8throw_type_error(scope, &format!("arg1: {}", err));
-            }
+        let Some(x) = decode_arg::<f64>(scope, &args, 1) else {
+            return;
         };
-        let y = match serde_v8::from_v8::<Arg2>(scope, args.get(2)) {
-            Ok(options) => options,
-            Err(err) => {
-                return core::v8throw_type_error(scope, &format!("arg2: {}", err));
-            }
+        let Some(y) = decode_arg::<f64>(scope, &args, 2) else {
+            return;
         };
-        let options = match serde_v8::from_v8::<Option<Arg3>>(scope, args.get(3)) {
-            Ok(options) => options,
-            Err(err) => {
-                return core::v8throw_type_error(scope, &format!("arg3: {}", err));
-            }
+        let Some(options) = decode_arg::<Option<Options>>(scope, &args, 3) else {
+            return;
         };
-        let shapes = match args.data().try_cast::<v8::Array>() {
-            Ok(v) => v,
-            Err(err) => {
-                return core::v8throw(
-                    scope,
-                    &format!("unexpected: \"this\" is not an array: {}", err),
-                );
-            }
-        };
-        let shape = Shape::Text {
-            text,
-            x,
-            y,
-            size: options.as_ref().and_then(|o| o.size),
-            color: options.as_ref().and_then(|o| o.color),
-        };
-        let shape_js = match serde_v8::to_v8(scope, &shape) {
-            Ok(v) => v.into(),
-            Err(err) => {
-                return core::v8throw(scope, &format!("unexpected: {}", err));
-            }
-        };
-        shapes.set_index(scope, shapes.length(), shape_js);
+        let options = options.unwrap_or_default();
+        push_shape(
+            scope,
+            &args,
+            Shape::Text {
+                text,
+                x,
+                y,
+                size: options.size,
+                color: options.color,
+            },
+        );
     }
-    v8::FunctionBuilder::<v8::Function>::new(callback)
-        .data(shapes.into())
-        .build(scope)
-        .ok_or(core::JsRuntimeError::RuntimeError(
-            "failed to create add_text function".to_string(),
-        ))
+    build_shape_fn(scope, shapes, callback, "add_text")
 }


### PR DESCRIPTION
## 概要
#7 の 3-2 の修正です。

`gen_api_add_polygon` / `gen_api_add_text` は「引数を serde_v8 でデコード → `data()` の配列に push」という 80% 同じ構造のコードでした。以下のヘルパーに集約します。

- `decode_arg<T>`: 引数のデコードと TypeError 送出
- `push_shape`: Shape のシリアライズと配列への追加
- `build_shape_fn`: shapes 配列に紐付けた `v8::Function` の生成

`type Arg0 = String;` のような読みにくい別名を廃止し、オプション引数は `#[derive(Default)]` 付きの `Options` 構造体に統一しました。挙動の変更はありません(引数省略時・型不一致時の挙動は既存テストで担保)。

`cargo test` 12 件全て成功を確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)