### PR TITLE
無限ループするスクリプトをウォッチドッグで強制終了する

### DIFF
--- a/crates/ps88/src/js/core/runtime.rs
+++ b/crates/ps88/src/js/core/runtime.rs
@@ -150,6 +150,11 @@ impl<'a> JsRuntime<'a> {
     pub fn scope(&mut self) -> v8::HandleScope {
         v8::HandleScope::with_context(&mut self.isolate, &self.context)
     }
+
+    // 別スレッドから JavaScript の実行を強制終了するためのハンドルを返す
+    pub fn isolate_handle(&self) -> v8::IsolateHandle {
+        self.isolate.thread_safe_handle()
+    }
 }
 
 #[cfg(test)]

--- a/crates/ps88/src/js/core/utils.rs
+++ b/crates/ps88/src/js/core/utils.rs
@@ -27,6 +27,9 @@ pub fn v8throw_type_error<'s>(scope: &mut v8::HandleScope<'s>, s: &str) {
 // TryCatch からエラー情報を文字列に変換する
 pub fn report_exceptions(try_catch: &mut v8::TryCatch<v8::HandleScope>) -> String {
     let mut description = Vec::<String>::new();
+    if try_catch.has_terminated() {
+        return "execution was terminated (script took too long)".into();
+    }
     let Some(exception) = try_catch.exception() else {
         return "no error".into();
     };

--- a/crates/ps88/src/js/ps88js/runtime.rs
+++ b/crates/ps88/src/js/ps88js/runtime.rs
@@ -58,6 +58,10 @@ impl Runtime<'_> {
     pub fn add_logger(&mut self, logger: Box<dyn Fn(String) -> bool + Sync + Send>) {
         self.logger.borrow_mut().push(logger);
     }
+    // 別スレッドから JavaScript の実行を強制終了するためのハンドルを返す
+    pub fn isolate_handle(&self) -> v8::IsolateHandle {
+        self.runtime.isolate_handle()
+    }
     pub fn reset(&mut self) -> core::Result<()> {
         self.runtime.reset()
     }

--- a/crates/ps88/src/js/ps88js/runtime_actor.rs
+++ b/crates/ps88/src/js/ps88js/runtime_actor.rs
@@ -2,8 +2,13 @@ use super::super::core;
 use super::gui_api::*;
 use super::runtime::*;
 use super::status::*;
-use std::sync::mpsc::{channel, Sender};
+use deno_core::v8;
+use std::sync::mpsc::{channel, Receiver, RecvTimeoutError, Sender};
 use std::sync::{Arc, Mutex};
+
+// スクリプトの実行がこの時間を超えて返ってこない場合、無限ループ等と
+// みなして JavaScript の実行を強制終了する
+const WATCHDOG_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
 
 // Runtime を複数スレッドから使えるようにするためのラッパー。
 // Runtime は Sync, Send を持たないため、そのままでは複数スレッドから使うことはできない。
@@ -14,6 +19,9 @@ pub struct RuntimeActor {
 
     // メソッドの引数は通常チャンネルで渡すが、サイズの大きいデータや参照型などは args 経由でやり取りする
     args: Arc<Mutex<RuntimeActorArgs>>,
+
+    // JavaScript の実行を強制終了するためのハンドル
+    isolate_handle: v8::IsolateHandle,
 }
 impl RuntimeActor {
     pub fn new(userdata: Arc<Mutex<UserData>>) -> core::Result<Self> {
@@ -23,13 +31,13 @@ impl RuntimeActor {
         }));
         let args_clone = args.clone();
         let (tx, rx) = channel::<RuntimeActorMessage>();
-        let (init_tx, init_rx) = channel::<core::Result<()>>();
+        let (init_tx, init_rx) = channel::<core::Result<v8::IsolateHandle>>();
         let handle = std::thread::spawn(move || {
             // Runtime の初期化に失敗した場合はスレッド内で panic せず、
             // 結果を呼び出し元に返してスレッドを終了する
             let mut runtime = match Runtime::new(userdata) {
                 Ok(runtime) => {
-                    let _ = init_tx.send(Ok(()));
+                    let _ = init_tx.send(Ok(runtime.isolate_handle()));
                     runtime
                 }
                 Err(err) => {
@@ -74,22 +82,38 @@ impl RuntimeActor {
                 }
             }
         });
-        init_rx.recv().map_err(|_| dead_actor_error())??;
+        let isolate_handle = init_rx.recv().map_err(|_| dead_actor_error())??;
         Ok(Self {
             handle,
             sender: tx,
             args,
+            isolate_handle,
         })
     }
     // アクタースレッドにメッセージを送り、応答を待つ。
     // アクタースレッドが停止している場合は panic せずエラーを返す。
-    fn request<R>(
-        &self,
-        msg: RuntimeActorMessage,
-        rx: std::sync::mpsc::Receiver<R>,
-    ) -> core::Result<R> {
+    // 応答が WATCHDOG_TIMEOUT を超えて返ってこない場合は、スクリプトが
+    // 無限ループ等に陥っているとみなして JavaScript の実行を強制終了する。
+    // (これがないと `while(true){}` のようなスクリプトを書いた時点で
+    //  オーディオスレッドが永久にブロックし、ホスト DAW がフリーズする)
+    fn request<R>(&self, msg: RuntimeActorMessage, rx: Receiver<R>) -> core::Result<R> {
         self.sender.send(msg).map_err(|_| dead_actor_error())?;
-        rx.recv().map_err(|_| dead_actor_error())
+        match rx.recv_timeout(WATCHDOG_TIMEOUT) {
+            Ok(result) => Ok(result),
+            Err(RecvTimeoutError::Timeout) => {
+                log::error!(
+                    "script did not finish within {:?}; terminating javascript execution",
+                    WATCHDOG_TIMEOUT
+                );
+                self.isolate_handle.terminate_execution();
+                let result = rx.recv().map_err(|_| dead_actor_error());
+                // タイムアウトの直後に実行が自然に終了していた場合、終了リクエストが
+                // 未消費のまま残って次の実行を巻き込むことがあるため取り消しておく
+                self.isolate_handle.cancel_terminate_execution();
+                result
+            }
+            Err(RecvTimeoutError::Disconnected) => Err(dead_actor_error()),
+        }
     }
     // ログ関数を追加する。ログ関数が false を返すとログの受信が終了する。
     pub fn add_logger(
@@ -362,6 +386,30 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn test_infinite_loop_termination() {
+        let userdata = Arc::new(Mutex::new(UserData::None));
+        let rt = RuntimeActor::new(userdata).unwrap();
+
+        // 無限ループするスクリプトは WATCHDOG_TIMEOUT 後に強制終了されエラーになる
+        rt.compile("for(;;){}").unwrap_err();
+
+        // その後も通常のスクリプトは問題なく実行できる
+        rt.compile("console.log('alive');").unwrap();
+
+        // audio コールバック内の無限ループも同様に強制終了される
+        rt.compile(
+            r#"
+                "use strict";
+                ps88.audio((ctx) => { for(;;){} });
+            "#,
+        )
+        .unwrap();
+        let mut audio = [&mut [0f32][..]];
+        let mut midi = vec![];
+        rt.audio(&mut audio[..], &mut midi, 48000., 0, 0.).unwrap_err();
     }
 
     #[test]


### PR DESCRIPTION
## 概要
#7 の 1-1 の修正です。

ユーザースクリプトが `while(true){}` などで返ってこない場合、`RuntimeActor` の `rx.recv()` が永久にブロックし、**オーディオスレッドごとホスト DAW がフリーズ**していました。任意のコードをユーザーに書かせるプラグインなので、通常のプラグインより起きやすい事故です。

## 実装

- `request()` の応答待ちを `recv_timeout` (3 秒) に変更し、タイムアウト時は `v8::IsolateHandle::terminate_execution()` で JavaScript の実行を強制終了します。終了後はアクタースレッドが通常どおりエラー応答を返すため、それを待って返します
- タイムアウトの直後に実行が自然終了していた場合、終了リクエストが未消費のまま残って次の実行を巻き込むため、応答受信後に `cancel_terminate_execution()` で取り消します
- `report_exceptions` に `has_terminated()` の判定を追加し、強制終了時は `execution was terminated (script took too long)` という分かりやすいメッセージを返します
- 強制終了後もランタイムが使い続けられること(compile / audio 両方)を確認するテストを追加しました

## 制限

- タイムアウトまでの最大 3 秒間はオーディオスレッドがブロックされたままです(完全なフリーズは防げますが、音は途切れます)。リアルタイム性の根本改善は #7 の 1-2 / 1-4 の範囲です

**Note:** この PR は `request()` ヘルパーを導入した #27 の上に積んでおり、ベースブランチも #27 (`fix/actor-panic-chain`) に向けてあります。#27 がマージされるとベースは自動的に main に切り替わります。

`cargo test` 13 件全て成功を確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
