### PR TITLE
process() 内のアロケーションを削減する

### DIFF
--- a/crates/ps88/src/js/ps88js/runtime_actor.rs
+++ b/crates/ps88/src/js/ps88js/runtime_actor.rs
@@ -22,6 +22,12 @@ pub struct RuntimeActor {
 
     // JavaScript の実行を強制終了するためのハンドル
     isolate_handle: v8::IsolateHandle,
+
+    // audio() 用の応答チャンネル。
+    // オーディオスレッドでのアロケーションを避けるため、毎回生成せず使い回す。
+    // (audio() は単一のオーディオスレッドから呼ばれる想定だが、
+    //  RuntimeActor を Sync に保つため Mutex で包んでいる)
+    audio_response: Mutex<Receiver<core::Result<()>>>,
 }
 impl RuntimeActor {
     pub fn new(userdata: Arc<Mutex<UserData>>) -> core::Result<Self> {
@@ -32,6 +38,7 @@ impl RuntimeActor {
         let args_clone = args.clone();
         let (tx, rx) = channel::<RuntimeActorMessage>();
         let (init_tx, init_rx) = channel::<core::Result<v8::IsolateHandle>>();
+        let (audio_tx, audio_rx) = channel::<core::Result<()>>();
         let handle = std::thread::spawn(move || {
             // Runtime の初期化に失敗した場合はスレッド内で panic せず、
             // 結果を呼び出し元に返してスレッドを終了する
@@ -63,12 +70,11 @@ impl RuntimeActor {
                         sample_rate,
                         pos_samples,
                         bpm,
-                        result,
                     } => {
                         let RuntimeActorArgs { audio, midi, .. } = &mut *args_clone.lock().unwrap();
                         let mut audio: Vec<&mut [f32]> =
                             audio.iter_mut().map(|ch| ch.as_mut_slice()).collect();
-                        let _ = result.send(runtime.audio(
+                        let _ = audio_tx.send(runtime.audio(
                             audio.as_mut_slice(),
                             midi,
                             sample_rate,
@@ -88,6 +94,7 @@ impl RuntimeActor {
             sender: tx,
             args,
             isolate_handle,
+            audio_response: Mutex::new(audio_rx),
         })
     }
     // アクタースレッドにメッセージを送り、応答を待つ。
@@ -96,7 +103,7 @@ impl RuntimeActor {
     // 無限ループ等に陥っているとみなして JavaScript の実行を強制終了する。
     // (これがないと `while(true){}` のようなスクリプトを書いた時点で
     //  オーディオスレッドが永久にブロックし、ホスト DAW がフリーズする)
-    fn request<R>(&self, msg: RuntimeActorMessage, rx: Receiver<R>) -> core::Result<R> {
+    fn request<R>(&self, msg: RuntimeActorMessage, rx: &Receiver<R>) -> core::Result<R> {
         self.sender.send(msg).map_err(|_| dead_actor_error())?;
         match rx.recv_timeout(WATCHDOG_TIMEOUT) {
             Ok(result) => Ok(result),
@@ -121,11 +128,11 @@ impl RuntimeActor {
         logger: Box<dyn Fn(String) -> bool + Sync + Send>,
     ) -> core::Result<()> {
         let (tx, rx) = channel();
-        self.request(RuntimeActorMessage::AddLogger { logger, result: tx }, rx)
+        self.request(RuntimeActorMessage::AddLogger { logger, result: tx }, &rx)
     }
     pub fn reset(&self) -> core::Result<()> {
         let (tx, rx) = channel();
-        self.request(RuntimeActorMessage::Reset { result: tx }, rx)?
+        self.request(RuntimeActorMessage::Reset { result: tx }, &rx)?
     }
     pub fn compile(&self, code: &str) -> core::Result<()> {
         let (tx, rx) = channel();
@@ -134,7 +141,7 @@ impl RuntimeActor {
                 code: code.to_string(),
                 result: tx,
             },
-            rx,
+            &rx,
         )?
     }
     pub fn audio(
@@ -155,28 +162,40 @@ impl RuntimeActor {
                     .zip(args.audio.iter())
                     .any(|(a, b)| a.len() != b.len())
             {
-                // audio の長さが変化した場合は再確保
-                args.audio = audio.iter().map(|ch| ch.to_vec()).collect();
+                // audio の長さが変化した場合は再確保 (通常は初回のみ)。
+                // オーディオスレッドだが意図したアロケーションであることを明示する。
+                nih_plug::util::permit_alloc(|| {
+                    args.audio = audio.iter().map(|ch| ch.to_vec()).collect();
+                });
             } else {
                 // 長さが同じ場合は内容だけコピー
                 for (ch, buf) in audio.iter().zip(args.audio.iter_mut()) {
                     buf.copy_from_slice(ch);
                 }
             }
-            std::mem::swap(&mut args.midi, midi);
+            // NOTE: swap だと呼び出し元の事前確保したバッファが args 側の
+            // バッファと入れ替わって失われるため、コピーで受け渡す。
+            // アロケーションはバッファが過去最大のイベント数を超えた時のみ発生する。
+            args.midi.clear();
+            nih_plug::util::permit_alloc(|| args.midi.extend_from_slice(midi));
         }
 
         // メッセージを送信して処理を待つ
-        let (tx, rx) = channel();
-        self.request(
-            RuntimeActorMessage::Audio {
-                sample_rate,
-                pos_samples,
-                bpm,
-                result: tx,
-            },
-            rx,
-        )??;
+        // NOTE: 応答チャンネルの生成はアロケーションを伴うため、audio() では
+        // 事前生成したチャンネルを使い回す。
+        // また std::sync::mpsc の送信は内部でノードを 1 つ確保するため、
+        // その分のみ明示的にアロケーションを許可する。
+        let audio_response = self.audio_response.lock().unwrap();
+        nih_plug::util::permit_alloc(|| {
+            self.request(
+                RuntimeActorMessage::Audio {
+                    sample_rate,
+                    pos_samples,
+                    bpm,
+                },
+                &audio_response,
+            )
+        })??;
 
         // args から audio & midi にコピー
         {
@@ -184,14 +203,15 @@ impl RuntimeActor {
             for (ch, buf) in audio.iter_mut().zip(args.audio.iter()) {
                 ch.copy_from_slice(buf);
             }
-            std::mem::swap(midi, &mut args.midi);
+            midi.clear();
+            nih_plug::util::permit_alloc(|| midi.extend_from_slice(&args.midi));
         }
 
         Ok(())
     }
     pub fn gui(&self, args: GuiArgs) -> core::Result<Vec<Shape>> {
         let (tx, rx) = channel();
-        self.request(RuntimeActorMessage::Gui { args, result: tx }, rx)?
+        self.request(RuntimeActorMessage::Gui { args, result: tx }, &rx)?
     }
 }
 
@@ -228,7 +248,6 @@ enum RuntimeActorMessage {
         sample_rate: f64,
         pos_samples: u64,
         bpm: f64,
-        result: Sender<core::Result<()>>,
     },
     Gui {
         args: GuiArgs,
@@ -386,6 +405,28 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn test_audio_repeated_calls() {
+        let userdata = Arc::new(Mutex::new(UserData::None));
+        let rt = RuntimeActor::new(userdata).unwrap();
+
+        // 応答チャンネルを使い回しても連続で呼び出せる
+        rt.compile(
+            r#"
+                "use strict";
+                let count = 0;
+                ps88.audio((ctx) => { ctx.audio[0][0] = count += 1; });
+            "#,
+        )
+        .unwrap();
+        let mut midi = vec![];
+        for i in 1..=5 {
+            let mut audio = [&mut [0f32][..]];
+            rt.audio(&mut audio[..], &mut midi, 0., 0, 0.).unwrap();
+            assert_eq!(audio[0][0], i as f32);
+        }
     }
 
     #[test]

--- a/crates/ps88/src/js/ps88js/status.rs
+++ b/crates/ps88/src/js/ps88js/status.rs
@@ -9,7 +9,7 @@ pub enum UserData {
     Text(String),
 }
 
-#[derive(Deserialize, Serialize, PartialEq, Debug)]
+#[derive(Deserialize, Serialize, PartialEq, Debug, Clone, Copy)]
 #[serde(tag = "type")]
 pub enum NoteEvent {
     #[serde(rename_all = "camelCase")]

--- a/crates/ps88/src/lib.rs
+++ b/crates/ps88/src/lib.rs
@@ -7,6 +7,10 @@ use gui::editor;
 use nih_plug::prelude::*;
 use std::sync::Arc;
 
+// 1 回の process() で扱う MIDI イベント数の目安。
+// これを超えるとオーディオスレッドでバッファの再確保が発生する。
+const MIDI_EVENT_CAPACITY: usize = 1024;
+
 pub struct PS88 {
     // プラグイン内で保持するデータ
     params: Arc<params::PS88Params>,
@@ -15,6 +19,9 @@ pub struct PS88 {
     runtime: Arc<js::ps88js::RuntimeActor>,
 
     pos_samples: i64,
+
+    // process() 内でのアロケーションを避けるための MIDI イベント用バッファ
+    midi: Vec<js::ps88js::NoteEvent>,
 }
 
 impl Default for PS88 {
@@ -26,6 +33,7 @@ impl Default for PS88 {
             params: Arc::new(params),
             runtime,
             pos_samples: 0,
+            midi: Vec::with_capacity(MIDI_EVENT_CAPACITY),
         }
     }
 }
@@ -103,7 +111,11 @@ impl Plugin for PS88 {
         context: &mut impl ProcessContext<Self>,
     ) -> ProcessStatus {
         // イベントを取得
-        let mut midi = Vec::<js::ps88js::NoteEvent>::new();
+        // NOTE: オーディオスレッドでのアロケーションを避けるため、
+        // 事前確保したバッファを再利用する。
+        // 事前確保した容量を超えた場合のみアロケーションが発生する。
+        let midi = &mut self.midi;
+        midi.clear();
         while let Some(event) = context.next_event() {
             match event {
                 NoteEvent::NoteOn {
@@ -113,12 +125,14 @@ impl Plugin for PS88 {
                     note,
                     velocity,
                 } => {
-                    midi.push(js::ps88js::NoteEvent::NoteOn {
-                        timing,
-                        voice_id,
-                        channel,
-                        note,
-                        velocity,
+                    util::permit_alloc(|| {
+                        midi.push(js::ps88js::NoteEvent::NoteOn {
+                            timing,
+                            voice_id,
+                            channel,
+                            note,
+                            velocity,
+                        })
                     });
                 }
                 NoteEvent::NoteOff {
@@ -128,12 +142,14 @@ impl Plugin for PS88 {
                     note,
                     velocity,
                 } => {
-                    midi.push(js::ps88js::NoteEvent::NoteOff {
-                        timing,
-                        voice_id,
-                        channel,
-                        note,
-                        velocity,
+                    util::permit_alloc(|| {
+                        midi.push(js::ps88js::NoteEvent::NoteOff {
+                            timing,
+                            voice_id,
+                            channel,
+                            note,
+                            velocity,
+                        })
                     });
                 }
                 // TODO: 他のイベントも処理する
@@ -146,7 +162,7 @@ impl Plugin for PS88 {
             let transport = context.transport();
             if let Err(e) = self.runtime.audio(
                 buffer.as_slice(),
-                &mut midi,
+                midi,
                 transport.sample_rate as f64,
                 transport.pos_samples().unwrap_or(self.pos_samples) as u64,
                 transport.tempo.unwrap_or(0.0),
@@ -157,7 +173,7 @@ impl Plugin for PS88 {
         }
 
         // midi の内容を context に書き戻す
-        for event in midi {
+        for event in midi.drain(..) {
             match event {
                 js::ps88js::NoteEvent::NoteOn {
                     timing,


### PR DESCRIPTION
## 概要
#7 の 1-2 の修正です。

`assert_process_allocs` feature が有効なのに `process()` の経路で毎回アロケーションが発生しており、デバッグビルドでは最初の `process()` で panic する状態でした。

## 変更内容

- **MIDI バッファの再利用**: 毎回 `Vec::new()` していた MIDI イベント収集を、事前確保 (1024 件) した `self.midi` の再利用に変更
- **応答チャンネルの使い回し**: `RuntimeActor::audio` が毎回 `channel()` を生成していたのを、構築時に生成したチャンネルの使い回しに変更 (`Mutex<Receiver>` として保持。audio は単一スレッドから呼ばれる想定のため競合しません)
- **swap → コピー**: `args.midi` との受け渡しが `mem::swap` だと呼び出し元の事前確保バッファがアクター側の(容量不明の)バッファと入れ替わってしまうため、コピーに変更しました (`NoteEvent` は全フィールドがスカラーなので `Copy` を導出)
- **残るアロケーションの明示**: 完全なアロケーションフリーには std の mpsc をロックフリーリングバッファ等に置き換える必要があるため、この PR では残る小さなアロケーション (mpsc 送信ノード 1 個/呼び出し、容量超過時のみの再確保) を `nih_plug::util::permit_alloc` で明示し、理由をコメントに残しています

これによりデバッグビルド + `assert_process_allocs` でも process が通常経路で panic しなくなり、リリースビルドでも定常状態のアロケーションがほぼゼロになります。

**Note:** この PR は #27 → #28 の上に積んでおり、ベースブランチも #28 (`fix/js-watchdog`) に向けてあります。マージは #27 → #28 → この PR の順で、親がマージされるとベースは自動的に切り替わります。

`cargo test` 14 件全て成功を確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
