### PR TITLE
リポジトリの細かい整理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,12 +1272,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "downcast"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
-
-[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1577,12 +1571,6 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fragile"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "fsevent-sys"
@@ -2393,32 +2381,6 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "mockall"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
-dependencies = [
- "cfg-if",
- "downcast",
- "fragile",
- "mockall_derive",
- "predicates",
- "predicates-tree",
-]
-
-[[package]]
-name = "mockall_derive"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn 2.0.96",
 ]
 
 [[package]]
@@ -3246,32 +3208,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "predicates"
-version = "3.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
-dependencies = [
- "anstyle",
- "predicates-core",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
-dependencies = [
- "predicates-core",
- "termtree",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3337,7 +3273,6 @@ dependencies = [
  "log",
  "lyon",
  "material-design-icons",
- "mockall",
  "nih_plug",
  "nih_plug_egui",
  "notify",
@@ -3883,12 +3818,6 @@ dependencies = [
  "rustix",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "termtree"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"

--- a/crates/ps88/Cargo.toml
+++ b/crates/ps88/Cargo.toml
@@ -3,7 +3,7 @@ name = "ps88"
 version.workspace = true
 edition.workspace = true
 authors = ["Taiki Yoshii"]
-license = "GPL-3.0"
+license.workspace = true
 
 keywords = ["synthesizer", "clap", "vst3"]
 description = "A programmable synthesizer"
@@ -25,6 +25,3 @@ notify = "7.0.0"
 log = "0.4.22"
 lyon = "1.0.1"
 arboard = "3.5.0"
-
-[dev-dependencies]
-mockall = "0.13.1"

--- a/crates/ps88/src/file_watcher.rs
+++ b/crates/ps88/src/file_watcher.rs
@@ -1,4 +1,3 @@
-#[cfg_attr(test, mockall::automock)]
 pub trait Watcher {
     fn watch(&mut self, path: &std::path::Path) -> Result<std::sync::mpsc::Receiver<()>, Error>;
 }


### PR DESCRIPTION
## 概要
#7 の 4-4 の修正です。

- `.gitignore` に `.DS_Store` を追加(グローバル gitignore を設定していないコントリビュータ対策)
- `crates/ps88/Cargo.toml` の `license` を `license.workspace = true` に統一(version / edition は既に workspace 継承だった)
- 未使用の `mockall` (dev-dependency) と `#[cfg_attr(test, mockall::automock)]` を削除。`MockWatcher` を使うテストが存在せず、コンパイル時間だけ消費していました。将来 `Watcher` のモックが必要になったら再導入すれば十分です

4-4 のうち以下は判断が必要なため、この PR には含めていません(Issue に残置)。

- `TODO.md` と `docs/todo/README.md` の二重管理解消(どちらに寄せるか)
- `deno_core` → `v8` + `serde_v8` 直接依存への変更(要調査)

**Note:** `.gitignore` / `Cargo.lock` を触るため #30 (CI 追加) の上に積んでおり、ベースブランチも #30 (`chore/ci`) に向けてあります。#30 がマージされるとベースは自動的に main に切り替わります。

`cargo test` 12 件全て成功を確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
